### PR TITLE
More offline test improvements

### DIFF
--- a/src/tests/localvocal-offline-test.cpp
+++ b/src/tests/localvocal-offline-test.cpp
@@ -499,12 +499,13 @@ int wmain(int argc, wchar_t *argv[])
 						if (false && now > max_wait)
 							break;
 
-						gf->input_cv->wait_for(
-							lock, std::chrono::milliseconds(10), [&] {
-								return gf->input_buffers->size == 0;
-							});
 						if (gf->input_buffers->size == 0)
 							break;
+
+						gf->input_cv->wait_for(
+							lock, std::chrono::milliseconds(1), [&] {
+								return gf->input_buffers->size == 0;
+							});
 					}
 					// push back current audio data to input circlebuf
 					for (size_t c = 0; c < gf->channels; c++) {

--- a/src/tests/localvocal-offline-test.cpp
+++ b/src/tests/localvocal-offline-test.cpp
@@ -472,10 +472,10 @@ int wmain(int argc, wchar_t *argv[])
 
 		obs_log(LOG_INFO, "Sending samples to whisper buffer");
 		// 25 ms worth of frames
-		int frames = gf->sample_rate * window_size_in_ms.count() / 1000;
+		size_t frames = gf->sample_rate * window_size_in_ms.count() / 1000;
 		const int frame_size_bytes = sizeof(float);
-		int frames_size_bytes = frames * frame_size_bytes;
-		int frames_count = 0;
+		size_t frames_size_bytes = frames * frame_size_bytes;
+		size_t frames_count = 0;
 		int64_t start_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
 					     std::chrono::system_clock::now().time_since_epoch())
 					     .count();

--- a/src/tests/localvocal-offline-test.cpp
+++ b/src/tests/localvocal-offline-test.cpp
@@ -46,6 +46,8 @@ void obs_log(int log_level, const char *format, ...)
 
 	auto diff = now - start;
 
+	static std::mutex log_mutex;
+	auto lock = std::lock_guard(log_mutex);
 	// print timestamp
 	printf("[%02d:%02d:%02d.%03d] [%02d:%02lld.%03lld] ", now_tm.tm_hour, now_tm.tm_min,
 	       now_tm.tm_sec, (int)(epoch.count() % 1000),


### PR DESCRIPTION
With these changes offline tests (with segments.json saving) now consistently run faster than realtime on my machine; on an internal test file (2.5 gb, ~4.5 hours) with logging changes from https://github.com/palana/obs-localvocal/tree/offline-test-logging I get the following output shortly before processing finishes:
```
[13:38:26.084] [20:41.538] [INFO] [file location: 263:50.000 elapsed: 20:31.076 rate: 12.9] waited 0 ms
```