### PR TITLE
Fix model downloader crash on shutdown

### DIFF
--- a/src/model-utils/model-downloader-ui.cpp
+++ b/src/model-utils/model-downloader-ui.cpp
@@ -66,8 +66,10 @@ void ModelDownloader::closeEvent(QCloseEvent *e)
 {
 	if (!this->mPrepareToClose)
 		e->ignore();
-	else
+	else {
 		QDialog::closeEvent(e);
+		deleteLater();
+	}
 }
 
 void ModelDownloader::close()

--- a/src/model-utils/model-downloader-ui.h
+++ b/src/model-utils/model-downloader-ui.h
@@ -50,8 +50,8 @@ protected:
 private:
 	QVBoxLayout *layout;
 	QProgressBar *progress_bar;
-	QThread *download_thread;
-	ModelDownloadWorker *download_worker;
+	QPointer<QThread> download_thread;
+	QPointer<ModelDownloadWorker> download_worker;
 	// Callback for when the download is finished
 	download_finished_callback_t download_finished_callback;
 	bool mPrepareToClose;


### PR DESCRIPTION
`download_thread` and `download_worker` are automatically being deleted when they were finished, leaving dangling pointers; accessing those pointers from the destructor of `ModelDownloader` causes OBS to crash for me on shutdown (or alternatively hang on shutdown with no visible windows)

Additionally, `ModelDownloader` was only being deleted at shutdown; with this it's instead deleted after it's closed