### PR TITLE
enable transcript rename for non-srt files

### DIFF
--- a/src/transcription-filter-callbacks.cpp
+++ b/src/transcription-filter-callbacks.cpp
@@ -1,4 +1,4 @@
-def _WIN32
+#ifdef _WIN32
 #define NOMINMAX
 #endif
 

--- a/src/transcription-filter-callbacks.cpp
+++ b/src/transcription-filter-callbacks.cpp
@@ -321,7 +321,7 @@ void recording_state_callback(enum obs_frontend_event event, void *data)
 			std::rename(gf_->output_file_path.c_str(), srt_file_name.c_str());
 		} else if (gf_->save_only_while_recording &&
 			gf_->rename_file_to_match_recording) {
-				obs_log(gf_->log_level, "Recording stopped. Rename transcript file.");
+			obs_log(gf_->log_level, "Recording stopped. Rename transcript file.");
 			// use obs_frontend_get_last_recording to get the last recording file name
 			std::string recording_file_name = obs_frontend_get_last_recording();
 			// get the recording suffix, to ensure the new suffix doesn't match and overwrite the video
@@ -333,7 +333,6 @@ void recording_state_callback(enum obs_frontend_event event, void *data)
 			// keep the extension from the transcript file
 			std::string transcript_file_suffix = gf_->output_file_path.substr(
 				gf_->output_file_path.find_last_of(".") + 1);
-
 			std::string srt_file_name = recording_file_name_sans_suffix + "." + transcript_file_suffix;
 			// ensure the user didn't originally name the transcript with a matching suffix to the video
 			if (transcript_file_suffix == recording_file_suffix) {
@@ -341,7 +340,7 @@ void recording_state_callback(enum obs_frontend_event event, void *data)
 			}
 			// rename the file
 			std::rename(gf_->output_file_path.c_str(), srt_file_name.c_str());
-	        }
+		}
 	}
 }
 

--- a/src/transcription-filter-callbacks.cpp
+++ b/src/transcription-filter-callbacks.cpp
@@ -1,4 +1,4 @@
-#ifdef _WIN32
+def _WIN32
 #define NOMINMAX
 #endif
 
@@ -319,7 +319,29 @@ void recording_state_callback(enum obs_frontend_event event, void *data)
 			std::string srt_file_name = recording_file_name + ".srt";
 			// rename the file
 			std::rename(gf_->output_file_path.c_str(), srt_file_name.c_str());
-		}
+		} else if (gf_->save_only_while_recording &&
+			gf_->rename_file_to_match_recording) {
+				obs_log(gf_->log_level, "Recording stopped. Rename transcript file.");
+			// use obs_frontend_get_last_recording to get the last recording file name
+			std::string recording_file_name = obs_frontend_get_last_recording();
+			// get the recording suffix, to ensure the new suffix doesn't match and overwrite the video
+			std::string recording_file_suffix = recording_file_name.substr(
+				recording_file_name.find_last_of(".") + 1);
+			// remove the recording extension
+			std::string recording_file_name_sans_suffix = recording_file_name.substr(
+				0, recording_file_name.find_last_of("."));
+			// keep the extension from the transcript file
+			std::string transcript_file_suffix = gf_->output_file_path.substr(
+				gf_->output_file_path.find_last_of(".") + 1);
+
+			std::string srt_file_name = recording_file_name_sans_suffix + "." + transcript_file_suffix;
+			// ensure the user didn't originally name the transcript with a matching suffix to the video
+			if (transcript_file_suffix == recording_file_suffix) {
+				srt_file_name = srt_file_name + ".txt";
+			}
+			// rename the file
+			std::rename(gf_->output_file_path.c_str(), srt_file_name.c_str());
+	        }
 	}
 }
 


### PR DESCRIPTION
Fixes #173 

This will rename any transcription file if the "rename" checkbox is checked. It will use the video recording filename, plus the transcript filename suffix.

- "transcript.txt" renamed to "2024-10-01 12-11-10.txt"

It also checks the video recording suffix to compare with the transcript suffix to ensure it doesn't overwrite the video, if the user set the suffix to ".mkv" or ".mp4" for some reason (for example). In that case, it will append a hardcoded ".txt" suffix to the renamed transcript file.

- "why-would-you-name-your-transcript-this.mkv" renamed to "2024-10-01 12-11-10.mkv.txt"